### PR TITLE
Addition of cycle table for RSQUAD

### DIFF
--- a/packages/core/src/components/cv-icon/_cv-icon.vue
+++ b/packages/core/src/components/cv-icon/_cv-icon.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-const spritePath = require('../../assets/images/component-icons.svg');
+const spritePath = require('../../component-icons.svg');
 
 export default {
   name: 'CvIcon',

--- a/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
@@ -1,0 +1,88 @@
+<template>
+  <th :aria-sort="sortOrder">
+    <button type="button" v-if="sortable" :class="['bx--table-sort', orderClass]" @click="onSortClick">
+      <span class="bx--table-header-label">{{ heading }}</span>
+      <ArrowDown16 class="bx--table-sort__icon" />
+      <Arrows16 class="bx--table-sort__icon-unsorted" />
+    </button>
+    <span v-else class="bx--table-header-label">
+      <div v-if="heading.substring(0, cycle.name.length) === cycle.name" class="cycleHeader">
+        <router-link
+          :to="{ name: 'cycles', params: { releaseID: releaseID, projectID: productID, cycleID: cycle.id } }"
+        >
+          {{ heading.substring(0, cycle.name.length) }} </router-link
+        >{{ heading.substring(cycle.name.length) }}
+      </div>
+      <p v-else>{{ heading }}</p>
+
+      <div class="status__icon datatable" v-if="heading.substring(0, cycle.name.length) === cycle.name">
+        <checkmark v-if="cycle.status === 100" class="status__icon-color--green" />
+        <warn v-else-if="cycle.status > 79" class="status__icon-color--yellow" />
+        <close v-else-if="cycle.status" class="status__icon-color--red" />
+        <na v-else class="status__icon-color--na" />
+        {{ cycle.status }}%
+      </div>
+    </span>
+  </th>
+</template>
+
+<script>
+import ArrowDown16 from '@carbon/icons-vue/es/arrow--down/16';
+import Arrows16 from '@carbon/icons-vue/es/arrows/16';
+
+import checkmark from '@rocketsoftware/icons-vue/checkmark--filled/16';
+import warn from '@rocketsoftware/icons-vue/warning--filled/16';
+import close from '@rocketsoftware/icons-vue/close--filled/16';
+import na from '@rocketsoftware/icons-vue/help--filled/16';
+
+const nextSortOrder = {
+  ascending: 'descending',
+  descending: 'none',
+  none: 'ascending',
+};
+
+export default {
+  name: 'CvDataTableHeading',
+  components: { ArrowDown16, Arrows16, checkmark, warn, close, na },
+  props: {
+    productID: [Number, String],
+    releaseID: [Number, String],
+    cycle: Object,
+    heading: { type: String, required: true },
+    sortable: Boolean,
+    order: { type: String, default: 'none' },
+  },
+  computed: {
+    sortOrder() {
+      if (this.order !== 'ascending' && this.order !== 'descending') {
+        return 'none';
+      } else {
+        return this.order;
+      }
+    },
+    sortText() {
+      return this.sortOrder !== 'descending'
+        ? 'Sort rows by this header in descending order'
+        : 'Sort rows by this header in ascending order';
+    },
+    orderClass() {
+      let result = '';
+      if (this.sortOrder === 'descending') {
+        result = 'bx--table-sort--active';
+      } else if (this.sortOrder === 'ascending') {
+        result = 'bx--table-sort--active bx--table-sort--ascending';
+      }
+      return result;
+    },
+  },
+  model: {
+    event: 'sort',
+    prop: 'order',
+  },
+  methods: {
+    onSortClick() {
+      this.$emit('sort', nextSortOrder[this.sortOrder]);
+    },
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
@@ -8,7 +8,7 @@
     <span v-else class="bx--table-header-label">
       <div v-if="heading.substring(0, cycle.name.length) === cycle.name" class="cycleHeader">
         <router-link
-          :to="{ name: 'cycles', params: { releaseID: releaseID, projectID: productID, cycleID: cycle.id } }"
+          :to="{ name: 'cycles', params: { releaseID: releaseID, projectID: projectID, cycleID: cycle.id } }"
         >
           {{ heading.substring(0, cycle.name.length) }} </router-link
         >{{ heading.substring(cycle.name.length) }}
@@ -45,7 +45,7 @@ export default {
   name: 'CvDataTableHeading',
   components: { ArrowDown16, Arrows16, checkmark, warn, close, na },
   props: {
-    productID: [Number, String],
+    projectID: [Number, String],
     releaseID: [Number, String],
     cycle: Object,
     heading: { type: String, required: true },

--- a/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/rsquad-cycle-table/_cv-data-table-heading.vue
@@ -30,10 +30,10 @@
 import ArrowDown16 from '@carbon/icons-vue/es/arrow--down/16';
 import Arrows16 from '@carbon/icons-vue/es/arrows/16';
 
-import checkmark from '@rocketsoftware/icons-vue/checkmark--filled/16';
-import warn from '@rocketsoftware/icons-vue/warning--filled/16';
-import close from '@rocketsoftware/icons-vue/close--filled/16';
-import na from '@rocketsoftware/icons-vue/help--filled/16';
+import checkmark from '@rocketsoftware/icons-vue/es/checkmark--filled/16';
+import warn from '@rocketsoftware/icons-vue/es/warning--filled/16';
+import close from '@rocketsoftware/icons-vue/es/close--filled/16';
+import na from '@rocketsoftware/icons-vue/es/help--filled/16';
 
 const nextSortOrder = {
   ascending: 'descending',

--- a/packages/core/src/components/rsquad-cycle-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/rsquad-cycle-table/_cv-data-table-row-inner.vue
@@ -1,0 +1,114 @@
+<template>
+  <tr class="cv-data-table-row-inner" :class="{ 'bx--parent-row': expandingRow, 'bx--expandable-row': dataExpanded }">
+    <td
+      v-if="dataSomeExpandingRows"
+      class="bx--table-expand"
+      :data-previous-value="dataExpanded ? 'collapsed' : 'expanded'"
+    >
+      <button v-if="expandingRow" class="bx--table-expand__button" @click="toggleExpand">
+        <ChevronRight16 class="bx--table-expand__svg" />
+      </button>
+    </td>
+    <td v-if="hasBatchActions" class="bx--table-column-checkbox">
+      <cv-checkbox :form-item="false" :value="value" v-model="dataChecked" @change="onChange" ref="rowChecked" />
+    </td>
+    <slot />
+    <td v-if="hasOverflowMenu" class="bx--table-column-menu">
+      <cv-overflow-menu flip-menu>
+        <cv-overflow-menu-item
+          v-for="(item, index) in overflowMenu"
+          :key="`${index}`"
+          @click="
+            onMenuItemClick({
+              rowValue: value,
+              menuIndex: index,
+              menuLabel: item,
+            })
+          "
+          >{{ item }}</cv-overflow-menu-item
+        >
+      </cv-overflow-menu>
+    </td>
+  </tr>
+</template>
+
+<script>
+import CvCheckbox from '../cv-checkbox/cv-checkbox';
+import CvOverflowMenu from '../cv-overflow-menu/cv-overflow-menu';
+import CvOverflowMenuItem from '../cv-overflow-menu/cv-overflow-menu-item';
+import uidMixin from '../../mixins/uid-mixin';
+import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
+
+export default {
+  name: 'CvDataTableRowInner',
+  components: { CvCheckbox, CvOverflowMenu, CvOverflowMenuItem, ChevronRight16 },
+  mixins: [uidMixin],
+  props: {
+    checked: Boolean,
+    expanded: Boolean,
+    expandingRow: Boolean,
+    overflowMenu: Array,
+    someExpandingRows: Boolean,
+    value: { type: String, requried: true },
+  },
+  model: {
+    event: 'change',
+    prop: 'checked',
+  },
+  data() {
+    return {
+      dataChecked: this.checked,
+      dataExpanded: this.expanded,
+      dataSomeExpandingRows: this.someExpandingRows,
+    };
+  },
+  watch: {
+    checked() {
+      this.dataChecked = this.checked;
+    },
+    expanded() {
+      this.dataExpanded = this.expanded;
+    },
+    someExpandingRows() {
+      this.dataSomeExpandingRows = this.someExpandingRows;
+    },
+  },
+  mounted() {
+    this.$parent.$emit('cv:mounted', this);
+  },
+  beforeDestroy() {
+    this.$parent.$emit('cv:beforeDestroy', this);
+  },
+  computed: {
+    isCvDataTableRow() {
+      return true;
+    },
+    hasOverflowMenu() {
+      return (this.overflowMenu && this.overflowMenu.length) || this.$slots['overflow-menu'];
+    },
+    hasBatchActions() {
+      return this.$parent.$parent.hasBatchActions;
+    },
+    isChecked() {
+      return this.dataChecked;
+    },
+  },
+  methods: {
+    onChange() {
+      this.$parent.$parent.onRowCheckChange(this.value, this.dataChecked);
+    },
+    onMenuItemClick(val) {
+      this.$parent.$parent.onMenuItemClick(val);
+    },
+    toggleExpand() {
+      this.dataExpanded = !this.dataExpanded;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.cv-data-table-row-inner .cv-checkbox.bx--checkbox-wrapper {
+  margin: 0;
+}
+</style>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-action.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-action.vue
@@ -1,0 +1,15 @@
+<template>
+  <button class="bx--overflow-menu bx--toolbar-action" v-on="$listeners">
+    <slot></slot>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'cv-data-table-action',
+  mounted() {
+    // ensure SVG has
+    this.$el.children[0].classList.add('class="bx--toolbar-action__icon');
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -11,10 +11,10 @@
 </template>
 
 <script>
-import checkmark from '@rocketsoftware/icons-vue/checkmark--filled/16';
-import warn from '@rocketsoftware/icons-vue/warning--filled/16';
-import close from '@rocketsoftware/icons-vue/close--filled/16';
-import na from '@rocketsoftware/icons-vue/help--filled/16';
+import checkmark from '@rocketsoftware/icons-vue/es/checkmark--filled/16';
+import warn from '@rocketsoftware/icons-vue/es/warning--filled/16';
+import close from '@rocketsoftware/icons-vue/es/close--filled/16';
+import na from '@rocketsoftware/icons-vue/es/help--filled/16';
 export default {
   name: 'CvDataTableCell',
   props: {

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -5,8 +5,9 @@
       <warn v-else-if="getStatus > 79" class="status__icon-color--yellow small" />
       <close v-else-if="getStatus" class="status__icon-color--red small" />
       <na v-else class="status__icon-color--na small" />
+      <slot />
     </div>
-    <div v-if="cycle.publish_method === 'taf' && this.$slots.default[0].text === cycle.name">
+    <div v-else-if="colIndex === 0 && cycle.executions[0].publish_method === 'taf'">
       <router-link
         :to="{
           name: 'executions',
@@ -17,9 +18,10 @@
             executionID: getID(cycle.name_slug),
           },
         }"
-      ></router-link>
+        >{{ this.$slots.default[0].text }}</router-link
+      >
     </div>
-    <slot />
+    <slot v-else />
   </td>
 </template>
 
@@ -47,8 +49,11 @@ export default {
     getStatus: function() {
       return parseInt(this.$slots.default[0].text.substring(0, this.$slots.default[0].text.length - 1));
     },
+  },
+  methods: {
     getID: function(name) {
-      return this.cycle.exectuions.filter(exec => exec.name_slug === name).id;
+      console.log(this.cycle.executions[0].id);
+      return this.cycle.executions[0].id;
     },
   },
 };

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -7,7 +7,9 @@
       <na v-else class="status__icon-color--na small" />
       <slot />
     </div>
-    <div v-else-if="colIndex === 0 && cycle.executions[0].publish_method === 'taf' && this.$slots.default[0].text.length">
+    <div
+      v-else-if="colIndex === 0 && cycle.executions[0].publish_method === 'taf' && this.$slots.default[0].text.length"
+    >
       <router-link
         :to="{
           name: 'executions',
@@ -52,7 +54,6 @@ export default {
   },
   methods: {
     getID: function() {
-      console.log(this.cycle.executions.filter(execution => execution.name === this.$slots.default[0].text)[0].id);
       return this.cycle.executions.filter(execution => execution.name === this.$slots.default[0].text)[0].id;
     },
   },

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -6,6 +6,19 @@
       <close v-else-if="getStatus" class="status__icon-color--red small" />
       <na v-else class="status__icon-color--na small" />
     </div>
+    <div v-if="cycle.publish_method === 'taf' && this.$slots.default[0].text === cycle.name">
+      <router-link
+        :to="{
+          name: 'executions',
+          params: {
+            releaseID: releaseID,
+            projectID: productID,
+            cycleID: cycle.id,
+            executionID: getID(cycle.name_slug),
+          },
+        }"
+      ></router-link>
+    </div>
     <slot />
   </td>
 </template>
@@ -20,6 +33,9 @@ export default {
   props: {
     cellStyle: {},
     cycle: Object,
+    colIndex: Number,
+    productID: [Number, String],
+    releaseID: [Number, String],
   },
   components: {
     checkmark,
@@ -30,6 +46,9 @@ export default {
   computed: {
     getStatus: function() {
       return parseInt(this.$slots.default[0].text.substring(0, this.$slots.default[0].text.length - 1));
+    },
+    getID: function(name) {
+      return this.cycle.exectuions.filter(exec => exec.name_slug === name).id;
     },
   },
 };

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -1,0 +1,36 @@
+<template>
+  <td :style="cellStyle">
+    <div class="status__icon last_elem" v-if="this.$slots.default[0].text.includes('%')">
+      <checkmark v-if="getStatus === 100" class="status__icon-color--green small" />
+      <warn v-else-if="getStatus > 79" class="status__icon-color--yellow small" />
+      <close v-else-if="getStatus" class="status__icon-color--red small" />
+      <na v-else class="status__icon-color--na small" />
+    </div>
+    <slot />
+  </td>
+</template>
+
+<script>
+import checkmark from '@rocketsoftware/icons-vue/checkmark--filled/16';
+import warn from '@rocketsoftware/icons-vue/warning--filled/16';
+import close from '@rocketsoftware/icons-vue/close--filled/16';
+import na from '@rocketsoftware/icons-vue/help--filled/16';
+export default {
+  name: 'CvDataTableCell',
+  props: {
+    cellStyle: {},
+    cycle: Object,
+  },
+  components: {
+    checkmark,
+    warn,
+    close,
+    na,
+  },
+  computed: {
+    getStatus: function() {
+      return parseInt(this.$slots.default[0].text.substring(0, this.$slots.default[0].text.length - 1));
+    },
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -7,7 +7,7 @@
       <na v-else class="status__icon-color--na small" />
       <slot />
     </div>
-    <div v-else-if="colIndex === 0 && cycle.executions[0].publish_method === 'taf'">
+    <div v-else-if="colIndex === 0 && cycle.executions[0].publish_method === 'taf' && this.$slots.default[0].text.length">
       <router-link
         :to="{
           name: 'executions',
@@ -15,7 +15,7 @@
             releaseID: releaseID,
             projectID: projectID,
             cycleID: cycle.id,
-            executionID: getID(cycle.name_slug),
+            executionID: getID(),
           },
         }"
         >{{ this.$slots.default[0].text }}</router-link
@@ -51,9 +51,9 @@ export default {
     },
   },
   methods: {
-    getID: function(name) {
-      console.log(this.cycle.executions[0].id);
-      return this.cycle.executions[0].id;
+    getID: function() {
+      console.log(this.cycle.executions.filter(execution => execution.name === this.$slots.default[0].text)[0].id);
+      return this.cycle.executions.filter(execution => execution.name === this.$slots.default[0].text)[0].id;
     },
   },
 };

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-cell.vue
@@ -13,7 +13,7 @@
           name: 'executions',
           params: {
             releaseID: releaseID,
-            projectID: productID,
+            projectID: projectID,
             cycleID: cycle.id,
             executionID: getID(cycle.name_slug),
           },
@@ -36,7 +36,7 @@ export default {
     cellStyle: {},
     cycle: Object,
     colIndex: Number,
-    productID: [Number, String],
+    projectID: [Number, String],
     releaseID: [Number, String],
   },
   components: {

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-row.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-row.vue
@@ -1,0 +1,78 @@
+<template>
+  <tbody v-if="someExpandingRows" class="cv-data-table-row cv-data-table-row--expandable">
+    <cv-data-table-row-inner
+      ref="row"
+      v-bind="$attrs"
+      v-on="$listeners"
+      :expanding-row="dataExpandable"
+      some-expanding-rows
+    >
+      <slot />
+    </cv-data-table-row-inner>
+    <tr v-if="dataExpandable" class="bx--expandable-row bx--expandable-row--hidden" data-child-row>
+      <td colspan="9999">
+        <div class="bx--child-row-inner-container">
+          <slot name="expandedContent" />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+  <cv-data-table-row-inner v-else ref="row" v-bind="$attrs" v-on="$listeners" class="cv-data-table-row">
+    <slot />
+  </cv-data-table-row-inner>
+</template>
+
+<script>
+import CvDataTableRowInner from './_cv-data-table-row-inner';
+
+export default {
+  name: 'CvDataTableRow',
+  components: { CvDataTableRowInner },
+  data() {
+    return {
+      dataExpandable: this.$slots.expandedContent !== undefined,
+      dataSomeExpandingRows: false,
+    };
+  },
+  mounted() {
+    this.$parent.$emit('cv:mounted', this);
+  },
+  updated() {
+    this.dataExpandable = this.$slots.expandedContent !== undefined;
+  },
+  beforeDestroy() {
+    this.$parent.$emit('cv:beforeDestroy', this);
+  },
+  computed: {
+    expandable() {
+      return this.dataExpandable;
+    },
+    isCvDataTableRow() {
+      return true;
+    },
+    isChecked: {
+      get() {
+        return this.$refs.row.dataChecked;
+      },
+      set(val) {
+        this.$refs.row.dataChecked = val;
+      },
+    },
+    someExpandingRows: {
+      get() {
+        return this.dataSomeExpandingRows;
+      },
+      set(val) {
+        this.dataSomeExpandingRows = val;
+
+        if (this.$refs.row) {
+          this.$refs.row.dataSomeExpandingRows = val;
+        }
+      },
+    },
+    value() {
+      return this.$refs.row.value;
+    },
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table-skeleton.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table-skeleton.vue
@@ -1,0 +1,50 @@
+<template>
+  <cv-data-table skeleton :data="data" :columns="cols" v-on="$listeners" v-bind="$attrs">
+    <template v-if="$slots['helper-text']" slot="helper-text">
+      <slot name="helper-text" />
+    </template>
+
+    <template v-if="$slots['batch-actions']" slot="batch-actions">
+      <slot name="batch-actions" />
+    </template>
+
+    <template v-if="$slots.actions" slot="actions">
+      <slot name="actions" />
+    </template>
+  </cv-data-table>
+</template>
+
+<script>
+import CvDataTable from './cv-data-table';
+
+const DEFAULTS = {
+  COLS: 5,
+  ROWS: 5,
+};
+
+export default {
+  name: 'CvDataTableSkeleton',
+  components: {
+    CvDataTable,
+  },
+  props: {
+    columns: { type: [Array, Number], default: DEFAULTS.COLS },
+    hasExpandables: Boolean,
+    rows: { type: Number, default: DEFAULTS.ROWS },
+  },
+  computed: {
+    data() {
+      return [...Array(Math.max(this.rows, 1))].map(item => Array(this.cols.length).fill(''));
+    },
+    cols() {
+      return typeof this.columns !== 'number' ? this.columns : Array(Math.max(this.columns, 1)).fill('');
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+// .cv-data-table .bx--table-column-checkbox .bx--checkbox-wrapper {
+//   margin: 0;
+// }
+</style>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
@@ -49,6 +49,9 @@
                 :key="`cell:${colIndex}:${rowIndex}`"
                 :style="dataStyle(colIndex)"
                 :cycle="cycle"
+                :colIndex="colIndex"
+                :productID="productID"
+                :releaseID="releaseID"
                 >{{ cell }}</cv-data-table-cell
               >
             </cv-data-table-row>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
@@ -7,80 +7,6 @@
           <slot name="helper-text">{{ helperText }}</slot>
         </p>
       </div>
-
-      <!--      <section class="bx&#45;&#45;table-toolbar">-->
-      <!--        <div v-if="batchActive" :style="{ minHeight: '48px', maxWidth: '0' }" />-->
-
-      <!--        <div-->
-      <!--          v-if="hasBatchActions"-->
-      <!--          class="bx&#45;&#45;batch-actions"-->
-      <!--          :class="{ 'bx&#45;&#45;batch-actions&#45;&#45;active': batchActive }"-->
-      <!--          aria-label="Table Action Bar"-->
-      <!--        >-->
-      <!--          <div class="bx&#45;&#45;action-list">-->
-      <!--            <slot name="batch-actions" />-->
-      <!--            <cv-button class="bx&#45;&#45;batch-summary__cancel" small @click="deselect">Cancel</cv-button>-->
-      <!--          </div>-->
-      <!--          <div class="bx&#45;&#45;batch-summary">-->
-      <!--            <p class="bx&#45;&#45;batch-summary__para">-->
-      <!--              <span data-items-selected>{{ dataRowsSelected.length }}</span>-->
-      <!--              items selected-->
-      <!--            </p>-->
-      <!--          </div>-->
-      <!--        </div>-->
-
-      <!--        <div v-if="($slots.actions || $listeners.search) && !batchActive" class="bx&#45;&#45;toolbar-content">-->
-      <!--          <div-->
-      <!--            v-if="$listeners.search"-->
-      <!--            :class="{-->
-      <!--              'bx&#45;&#45;toolbar-search-container-active': searchActive,-->
-      <!--              'bx&#45;&#45;toolbar-search-container-persistent': !expandingSearch,-->
-      <!--              'bx&#45;&#45;toolbar-search-container-expandable': expandingSearch,-->
-      <!--            }"-->
-      <!--            ref="searchContainer"-->
-      <!--          >-->
-      <!--            <div data-search class="bx&#45;&#45;search bx&#45;&#45;search&#45;&#45;sm" role="search">-->
-      <!--              <div-->
-      <!--                class="bx&#45;&#45;search-magnifier"-->
-      <!--                tabindex="0"-->
-      <!--                @click="checkSearchExpand(true)"-->
-      <!--                @keydown.enter.prevent="checkSearchExpand(true)"-->
-      <!--                @keydown.space.prevent-->
-      <!--                @keyup.space.prevent="checkSearchExpand(true)"-->
-      <!--                @blur="checkSearchFocus"-->
-      <!--                ref="magnifier"-->
-      <!--              >-->
-      <!--                <Search16 class="bx&#45;&#45;toolbar-action__icon" />-->
-      <!--              </div>-->
-      <!--              <label :for="uid" class="bx&#45;&#45;label">Search</label>-->
-      <!--              <input-->
-      <!--                class="bx&#45;&#45;search-input"-->
-      <!--                type="text"-->
-      <!--                :id="uid"-->
-      <!--                role="search"-->
-      <!--                placeholder="Search"-->
-      <!--                :aria-labelledby="uid"-->
-      <!--                ref="search"-->
-      <!--                v-model="searchValue"-->
-      <!--                @input="onSearch"-->
-      <!--                @blur="checkSearchFocus"-->
-      <!--                @keydown.esc.prevent="checkSearchExpand(false)"-->
-      <!--              />-->
-      <!--              <button-->
-      <!--                class="bx&#45;&#45;search-close"-->
-      <!--                :class="{ 'bx&#45;&#45;search-close&#45;&#45;hidden': !clearSearchVisible }"-->
-      <!--                title="Clear search input"-->
-      <!--                aria-label="Clear search input"-->
-      <!--                @click="onClearClick"-->
-      <!--              >-->
-      <!--                <Close16 />-->
-      <!--              </button>-->
-      <!--            </div>-->
-      <!--          </div>-->
-      <!--          <slot name="actions" />-->
-      <!--        </div>-->
-      <!--      </section>-->
-
       <table class="bx--data-table" :class="modifierClasses">
         <thead>
           <tr>
@@ -118,22 +44,6 @@
               ref="dataRows"
               :overflow-menu="overflowMenu"
             >
-              <!--              <div v-for="(cell, colIndex) in row">-->
-              <!--                <div v-if="(cycle.status === cell) || cell === 0">-->
-              <!--                  <cv-data-table-cell-->
-              <!--                    :key="`cell:${colIndex}:${rowIndex}`"-->
-              <!--                    :style="dataStyle(colIndex)"-->
-              <!--                    >{{ cell }}</cv-data-table-cell-->
-              <!--                  >-->
-              <!--                </div>-->
-              <!--                <div v-else>-->
-              <!--                  <cv-data-table-cell-->
-              <!--                    :key="`cell:${colIndex}:${rowIndex}`"-->
-              <!--                    :style="dataStyle(colIndex)"-->
-              <!--                    >{{ cell }}</cv-data-table-cell-->
-              <!--                  >-->
-              <!--                </div>-->
-              <!--              </div>-->
               <cv-data-table-cell
                 v-for="(cell, colIndex) in row"
                 :key="`cell:${colIndex}:${rowIndex}`"
@@ -176,7 +86,7 @@ import Close16 from '@carbon/icons-vue/es/close/16';
 const rows = children => children.filter(child => child.isCvDataTableRow);
 
 export default {
-  name: 'RSquadCycleTable',
+  name: 'RsquadCycleTable',
   components: {
     CvButton,
     CvDataTableHeading,

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
@@ -1,0 +1,437 @@
+<template>
+  <div :style="tableStyle" class="cv-data-table">
+    <div class="bx--data-table-container">
+      <div class="bx--data-table-header">
+        <h4 class="bx--data-table-header__title" v-if="title">{{ title }}</h4>
+        <p v-if="isHelper" class="bx--data-table-header__description">
+          <slot name="helper-text">{{ helperText }}</slot>
+        </p>
+      </div>
+
+      <!--      <section class="bx&#45;&#45;table-toolbar">-->
+      <!--        <div v-if="batchActive" :style="{ minHeight: '48px', maxWidth: '0' }" />-->
+
+      <!--        <div-->
+      <!--          v-if="hasBatchActions"-->
+      <!--          class="bx&#45;&#45;batch-actions"-->
+      <!--          :class="{ 'bx&#45;&#45;batch-actions&#45;&#45;active': batchActive }"-->
+      <!--          aria-label="Table Action Bar"-->
+      <!--        >-->
+      <!--          <div class="bx&#45;&#45;action-list">-->
+      <!--            <slot name="batch-actions" />-->
+      <!--            <cv-button class="bx&#45;&#45;batch-summary__cancel" small @click="deselect">Cancel</cv-button>-->
+      <!--          </div>-->
+      <!--          <div class="bx&#45;&#45;batch-summary">-->
+      <!--            <p class="bx&#45;&#45;batch-summary__para">-->
+      <!--              <span data-items-selected>{{ dataRowsSelected.length }}</span>-->
+      <!--              items selected-->
+      <!--            </p>-->
+      <!--          </div>-->
+      <!--        </div>-->
+
+      <!--        <div v-if="($slots.actions || $listeners.search) && !batchActive" class="bx&#45;&#45;toolbar-content">-->
+      <!--          <div-->
+      <!--            v-if="$listeners.search"-->
+      <!--            :class="{-->
+      <!--              'bx&#45;&#45;toolbar-search-container-active': searchActive,-->
+      <!--              'bx&#45;&#45;toolbar-search-container-persistent': !expandingSearch,-->
+      <!--              'bx&#45;&#45;toolbar-search-container-expandable': expandingSearch,-->
+      <!--            }"-->
+      <!--            ref="searchContainer"-->
+      <!--          >-->
+      <!--            <div data-search class="bx&#45;&#45;search bx&#45;&#45;search&#45;&#45;sm" role="search">-->
+      <!--              <div-->
+      <!--                class="bx&#45;&#45;search-magnifier"-->
+      <!--                tabindex="0"-->
+      <!--                @click="checkSearchExpand(true)"-->
+      <!--                @keydown.enter.prevent="checkSearchExpand(true)"-->
+      <!--                @keydown.space.prevent-->
+      <!--                @keyup.space.prevent="checkSearchExpand(true)"-->
+      <!--                @blur="checkSearchFocus"-->
+      <!--                ref="magnifier"-->
+      <!--              >-->
+      <!--                <Search16 class="bx&#45;&#45;toolbar-action__icon" />-->
+      <!--              </div>-->
+      <!--              <label :for="uid" class="bx&#45;&#45;label">Search</label>-->
+      <!--              <input-->
+      <!--                class="bx&#45;&#45;search-input"-->
+      <!--                type="text"-->
+      <!--                :id="uid"-->
+      <!--                role="search"-->
+      <!--                placeholder="Search"-->
+      <!--                :aria-labelledby="uid"-->
+      <!--                ref="search"-->
+      <!--                v-model="searchValue"-->
+      <!--                @input="onSearch"-->
+      <!--                @blur="checkSearchFocus"-->
+      <!--                @keydown.esc.prevent="checkSearchExpand(false)"-->
+      <!--              />-->
+      <!--              <button-->
+      <!--                class="bx&#45;&#45;search-close"-->
+      <!--                :class="{ 'bx&#45;&#45;search-close&#45;&#45;hidden': !clearSearchVisible }"-->
+      <!--                title="Clear search input"-->
+      <!--                aria-label="Clear search input"-->
+      <!--                @click="onClearClick"-->
+      <!--              >-->
+      <!--                <Close16 />-->
+      <!--              </button>-->
+      <!--            </div>-->
+      <!--          </div>-->
+      <!--          <slot name="actions" />-->
+      <!--        </div>-->
+      <!--      </section>-->
+
+      <table class="bx--data-table" :class="modifierClasses">
+        <thead>
+          <tr>
+            <th v-if="hasExpandables" class="bx--table-expand" />
+            <th v-if="hasBatchActions" class="bx--table-column-checkbox">
+              <cv-checkbox
+                :form-item="false"
+                value="headingCheck"
+                v-model="headingChecked"
+                @change="onHeadingCheckChange"
+              />
+            </th>
+            <cv-data-table-heading
+              v-for="(column, index) in dataColumns"
+              :key="`${index}:${column}`"
+              :heading="column.label ? column.label : column"
+              :sortable="sortable"
+              :order="column.order"
+              @sort="val => onSort(index, val)"
+              :style="headingStyle(index)"
+              :productID="productID"
+              :releaseID="releaseID"
+              :cycle="cycle"
+            />
+            <th v-if="hasOverflowMenu"></th>
+          </tr>
+        </thead>
+
+        <cv-wrapper :tag-type="hasExpandables ? '' : 'tbody'">
+          <slot name="data">
+            <cv-data-table-row
+              v-for="(row, rowIndex) in data"
+              :key="`row:${rowIndex}`"
+              :value="`${rowIndex}`"
+              ref="dataRows"
+              :overflow-menu="overflowMenu"
+            >
+              <!--              <div v-for="(cell, colIndex) in row">-->
+              <!--                <div v-if="(cycle.status === cell) || cell === 0">-->
+              <!--                  <cv-data-table-cell-->
+              <!--                    :key="`cell:${colIndex}:${rowIndex}`"-->
+              <!--                    :style="dataStyle(colIndex)"-->
+              <!--                    >{{ cell }}</cv-data-table-cell-->
+              <!--                  >-->
+              <!--                </div>-->
+              <!--                <div v-else>-->
+              <!--                  <cv-data-table-cell-->
+              <!--                    :key="`cell:${colIndex}:${rowIndex}`"-->
+              <!--                    :style="dataStyle(colIndex)"-->
+              <!--                    >{{ cell }}</cv-data-table-cell-->
+              <!--                  >-->
+              <!--                </div>-->
+              <!--              </div>-->
+              <cv-data-table-cell
+                v-for="(cell, colIndex) in row"
+                :key="`cell:${colIndex}:${rowIndex}`"
+                :style="dataStyle(colIndex)"
+                :cycle="cycle"
+                >{{ cell }}</cv-data-table-cell
+              >
+            </cv-data-table-row>
+          </slot>
+        </cv-wrapper>
+      </table>
+    </div>
+
+    <cv-pagination
+      v-if="pagination"
+      :backward-text="pagination.backwardText"
+      :forward-text="pagination.forwardText"
+      :number-of-items="internalNumberOfItems"
+      :page="pagination.page"
+      :page-number-label="pagination.pageNumberLabel"
+      :page-sizes-label="pagination.pageSizesLabel"
+      :page-sizes="pagination.pageSizes"
+      @change="$emit('pagination', $event)"
+    ></cv-pagination>
+  </div>
+</template>
+
+<script>
+import CvDataTableHeading from './_cv-data-table-heading';
+import CvDataTableRow from './cv-data-table-row';
+import CvDataTableCell from './cv-data-table-cell';
+import CvButton from '../cv-button/cv-button';
+import CvCheckbox from '../cv-checkbox/cv-checkbox';
+import CvPagination from '../cv-pagination/cv-pagination';
+import CvWrapper from '../cv-wrapper/_cv-wrapper';
+import uidMixin from '../../mixins/uid-mixin';
+import Search16 from '@carbon/icons-vue/es/search/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
+
+const rows = children => children.filter(child => child.isCvDataTableRow);
+
+export default {
+  name: 'RSquadCycleTable',
+  components: {
+    CvButton,
+    CvDataTableHeading,
+    CvDataTableRow,
+    CvDataTableCell,
+    CvCheckbox,
+    CvPagination,
+    CvWrapper,
+    Search16,
+    Close16,
+  },
+  mixins: [uidMixin],
+  props: {
+    productID: [Number, String],
+    releaseID: [Number, String],
+    cycle: Object,
+    autoWidth: Boolean,
+    borderless: Boolean,
+    overflowMenu: { type: [Boolean, Array], default: () => [] },
+    pagination: {
+      type: [Boolean, Object],
+      default: false,
+    },
+    rowSize: {
+      type: String,
+      default: 'standard',
+      validator: val => ['compact', 'short', 'standard', 'tall', ''].includes(val),
+    },
+    searchPlaceholder: { type: String, default: 'filter' },
+    sortable: Boolean,
+    title: String,
+    columns: { type: Array, required: true },
+    data: { type: Array, requried: true },
+    zebra: Boolean,
+    rowsSelected: { type: Array, default: () => [] },
+    helperText: { type: String, default: null },
+    expandingSearch: { type: Boolean, default: true },
+  },
+  model: {
+    prop: 'rows-selected',
+    event: 'row-select-changes',
+  },
+  data() {
+    return {
+      dataColumns: this.sortable
+        ? this.columns.map(item => ({
+            label: item.label ? item.label : item,
+            order: 'none',
+          }))
+        : this.columns,
+      batchActive: false,
+      headingChecked: false,
+      dataRowsSelected: this.rowsSelected,
+      searchValue: '',
+      clearSearchVisible: false,
+      searchActive: false,
+      registeredRows: [],
+    };
+  },
+  watch: {
+    sortable() {
+      this.watchColumns();
+    },
+    columns() {
+      this.watchColumns();
+    },
+    rowsSelected() {
+      this.updateRowsSelected();
+    },
+  },
+  created() {
+    // add these on created otherwise cv:mounted is too late.
+    this.$on('cv:mounted', srcComponent => this.onCvMount(srcComponent));
+    this.$on('cv:beforeDestroy', srcComponent => this.onCvBeforeDestroy(srcComponent));
+  },
+  mounted() {
+    this.updateRowsSelected();
+  },
+  computed: {
+    hasBatchActions() {
+      return this.$slots['batch-actions'];
+    },
+    hasExpandables() {
+      return this.registeredRows.some(item => item.expandable);
+    },
+    hasOverflowMenu() {
+      return this.overflowMenu === true || (this.overflowMenu && this.overflowMenu.length > 0);
+    },
+    tableStyle() {
+      return this.autoWidth ? { width: 'initial' } : { width: '100%' };
+    },
+    internalPagination() {
+      if (typeof this.pagination === 'object') {
+        return this.pagination;
+      } else {
+        if (this.pagination === true) {
+          return {};
+        }
+      }
+      return false;
+    },
+    internalNumberOfItems() {
+      if (this.internalPagination.numberOfItems !== undefined) {
+        return this.internalPagination.numberOfItems;
+      } else {
+        return this.registeredRows.length;
+      }
+    },
+    modifierClasses() {
+      const prefix = 'bx--data-table--';
+      const sizeClass = this.rowSize.length === 0 || this.rowSize === 'standard' ? '' : `${prefix}${this.rowSize} `;
+      const zebraClass = this.zebra ? `${prefix}zebra ` : '';
+      const borderlessClass = this.borderless ? `${prefix}no-border ` : '';
+      return `${sizeClass}${zebraClass}${borderlessClass}`.trimRight();
+    },
+    headingStyle() {
+      return index => this.columns[index].headingStyle;
+    },
+    dataStyle() {
+      return index => this.columns[index].dataStyle;
+    },
+    selectedRows() {
+      return this.dataRowsSelected;
+    },
+    isHelper() {
+      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
+    },
+  },
+  methods: {
+    onCvMount(row) {
+      this.registeredRows.push(row);
+      this.updateSomeExpandingRows();
+    },
+    onCvBeforeDestroy(row) {
+      const index = this.registeredRows.findIndex(item => row.uid === item.uid);
+      this.registeredRows.slice(index, 1);
+      this.updateSomeExpandingRows();
+    },
+    checkSearchFocus(ev) {
+      if (!this.$refs.searchContainer.contains(ev.relatedTarget)) {
+        this.searchActive = false;
+      }
+    },
+    checkSearchExpand(force) {
+      if (typeof force === 'boolean') {
+        this.searchActive = force;
+      } else {
+        this.searchActive = !this.searchActive;
+      }
+      if (this.searchActive) {
+        this.$nextTick(() => {
+          this.$refs.search.focus();
+        });
+      } else {
+        this.$nextTick(() => {
+          this.$refs.magnifier.focus();
+        });
+      }
+    },
+    updateRowsSelected() {
+      this.dataRowsSelected = [];
+      for (const i in this.$children) {
+        let child = this.$children[i];
+        if (child.isCvDataTableRow) {
+          child.isChecked = this.rowsSelected.includes(child.value);
+
+          if (child.isChecked) {
+            this.dataRowsSelected.push(child.value);
+          }
+        }
+      }
+      this.headingChecked =
+        this.dataRowsSelected.length === this.$children.filter(item => item.isCvDataTableRow).length;
+      this.batchActive = this.dataRowsSelected.length > 0;
+    },
+    onClearClick() {
+      this.searchValue = '';
+      this.clearSearchVisible = false;
+      this.$emit('search', this.searchValue);
+      this.$nextTick(() => {
+        this.$refs.search.focus();
+      });
+    },
+    onHeadingCheckChange() {
+      // check /uncheck all children
+      this.batchActive = this.headingChecked;
+      this.dataRowsSelected = [];
+      for (const child of rows(this.$children)) {
+        if (this.headingChecked) {
+          this.dataRowsSelected.push(child.value);
+        }
+
+        if (child.isChecked !== this.headingChecked) {
+          child.isChecked = this.headingChecked;
+
+          this.$emit('row-select-change', {
+            value: child.value,
+            selected: child.isChecked,
+          });
+        }
+      }
+      this.$emit('row-select-changes', this.dataRowsSelected);
+    },
+    deselect() {
+      this.headingChecked = false;
+      this.onHeadingCheckChange();
+    },
+    onRowCheckChange(value, checked) {
+      let modelSet = new Set(this.dataRowsSelected);
+
+      if (!checked) {
+        modelSet.delete(value);
+      } else {
+        modelSet.add(value);
+      }
+      this.dataRowsSelected = Array.from(modelSet);
+      this.headingChecked = this.dataRowsSelected.length === rows(this.$children).length;
+      this.batchActive = this.dataRowsSelected.length > 0;
+
+      this.$emit('row-select-change', { value, selected: checked });
+      this.$emit('row-select-changes', this.dataRowsSelected);
+    },
+    onMenuItemClick(val) {
+      this.$emit('overflow-menu-click', val);
+    },
+    watchColumns() {
+      this.dataColumns = this.sortable
+        ? this.columns.map(item => ({
+            label: item.label ? item.label : item,
+            order: 'none',
+          }))
+        : this.columns;
+    },
+    onSearch() {
+      this.clearSearchVisible = this.searchValue.length > 0;
+      this.$emit('search', this.searchValue);
+    },
+    onSort(index, val) {
+      for (let column of this.dataColumns) {
+        column.order = 'none';
+      }
+      this.dataColumns[index].order = val;
+      this.$emit('sort', { index, order: val });
+    },
+    updateSomeExpandingRows() {
+      for (const child of rows(this.$children)) {
+        child.someExpandingRows = this.hasExpandables;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.cv-data-table .bx--table-column-checkbox .bx--checkbox-wrapper {
+  margin: 0;
+}
+</style>

--- a/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
+++ b/packages/core/src/components/rsquad-cycle-table/cv-data-table.vue
@@ -27,7 +27,7 @@
               :order="column.order"
               @sort="val => onSort(index, val)"
               :style="headingStyle(index)"
-              :productID="productID"
+              :projectID="projectID"
               :releaseID="releaseID"
               :cycle="cycle"
             />
@@ -50,7 +50,7 @@
                 :style="dataStyle(colIndex)"
                 :cycle="cycle"
                 :colIndex="colIndex"
-                :productID="productID"
+                :projectID="projectID"
                 :releaseID="releaseID"
                 >{{ cell }}</cv-data-table-cell
               >
@@ -103,7 +103,7 @@ export default {
   },
   mixins: [uidMixin],
   props: {
-    productID: [Number, String],
+    projectID: [Number, String],
     releaseID: [Number, String],
     cycle: Object,
     autoWidth: Boolean,

--- a/packages/core/src/components/rsquad-cycle-table/index.js
+++ b/packages/core/src/components/rsquad-cycle-table/index.js
@@ -1,0 +1,7 @@
+import CvDataTableAction from './cv-data-table-action';
+import CvDataTableCell from './cv-data-table-cell';
+import CvDataTableRow from './cv-data-table-row';
+import RsquadCycleTable from './cv-data-table';
+import CvDataTableSkeleton from './cv-data-table-skeleton';
+
+export { RsquadCycleTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableSkeleton };

--- a/packages/core/src/components/rsquad-exec-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/rsquad-exec-table/_cv-data-table-heading.vue
@@ -1,0 +1,71 @@
+<template>
+  <th :aria-sort="sortOrder">
+    <button type="button" v-if="sortable" :class="['bx--table-sort', orderClass]" @click="onSortClick">
+      <cv-wrapper :tag-type="headingLabelTag" class="bx--table-header-label">{{ heading }}</cv-wrapper>
+      <ArrowDown16 class="bx--table-sort__icon" />
+      <Arrows16 class="bx--table-sort__icon-unsorted" />
+    </button>
+    <cv-wrapper v-else-if="heading === 'Result' && filtered" :tag-type="headingLabelTag" class="bx--table-header-label">Result <filt/><filter </cv-wrapper>
+    <cv-wrapper v-else :tag-type="headingLabelTag" class="bx--table-header-label">{{ heading }}</cv-wrapper>
+  </th>
+</template>
+
+<script>
+import ArrowDown16 from '@rocketsoftware/icons-vue/es/arrow--down/16';
+import Arrows16 from '@rocketsoftware/icons-vue/es/arrows/16';
+import CvWrapper from '../cv-wrapper/_cv-wrapper';
+import filt from '@rocketsoftware/icons-vue/es/filter/16'
+
+const nextSortOrder = {
+  ascending: 'descending',
+  descending: 'none',
+  none: 'ascending',
+};
+
+export default {
+  name: 'CvDataTableHeading',
+  components: { ArrowDown16, Arrows16, CvWrapper, filt },
+  props: {
+    filtered: {type: Boolean, default: false},
+    heading: { type: String, required: true },
+    sortable: Boolean,
+    order: { type: String, default: 'none' },
+    skeleton: Boolean,
+  },
+  computed: {
+    sortOrder() {
+      if (this.order !== 'ascending' && this.order !== 'descending') {
+        return 'none';
+      } else {
+        return this.order;
+      }
+    },
+    sortText() {
+      return this.sortOrder !== 'descending'
+        ? 'Sort rows by this header in descending order'
+        : 'Sort rows by this header in ascending order';
+    },
+    orderClass() {
+      let result = '';
+      if (this.sortOrder === 'descending') {
+        result = 'bx--table-sort--active';
+      } else if (this.sortOrder === 'ascending') {
+        result = 'bx--table-sort--active bx--table-sort--ascending';
+      }
+      return result;
+    },
+    headingLabelTag() {
+      return this.heading.length === 0 || !this.skeleton ? 'span' : '';
+    },
+  },
+  model: {
+    event: 'sort',
+    prop: 'order',
+  },
+  methods: {
+    onSortClick() {
+      this.$emit('sort', nextSortOrder[this.sortOrder]);
+    },
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-exec-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/rsquad-exec-table/_cv-data-table-heading.vue
@@ -5,7 +5,9 @@
       <ArrowDown16 class="bx--table-sort__icon" />
       <Arrows16 class="bx--table-sort__icon-unsorted" />
     </button>
-    <cv-wrapper v-else-if="heading === 'Result' && filtered" :tag-type="headingLabelTag" class="bx--table-header-label">Result <filt/><filter </cv-wrapper>
+    <cv-wrapper v-else-if="heading === 'Result' && filtered" :tag-type="headingLabelTag" class="bx--table-header-label"
+      >Result <filt
+    /></cv-wrapper>
     <cv-wrapper v-else :tag-type="headingLabelTag" class="bx--table-header-label">{{ heading }}</cv-wrapper>
   </th>
 </template>
@@ -14,7 +16,7 @@
 import ArrowDown16 from '@rocketsoftware/icons-vue/es/arrow--down/16';
 import Arrows16 from '@rocketsoftware/icons-vue/es/arrows/16';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
-import filt from '@rocketsoftware/icons-vue/es/filter/16'
+import filt from '@rocketsoftware/icons-vue/es/filter/16';
 
 const nextSortOrder = {
   ascending: 'descending',
@@ -26,7 +28,7 @@ export default {
   name: 'CvDataTableHeading',
   components: { ArrowDown16, Arrows16, CvWrapper, filt },
   props: {
-    filtered: {type: Boolean, default: false},
+    filtered: { type: Boolean, default: false },
     heading: { type: String, required: true },
     sortable: Boolean,
     order: { type: String, default: 'none' },

--- a/packages/core/src/components/rsquad-exec-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/rsquad-exec-table/_cv-data-table-row-inner.vue
@@ -1,0 +1,114 @@
+<template>
+  <tr class="cv-data-table-row-inner" :class="{ 'bx--parent-row': expandingRow, 'bx--expandable-row': dataExpanded }">
+    <td
+      v-if="dataSomeExpandingRows"
+      class="bx--table-expand"
+      :data-previous-value="dataExpanded ? 'collapsed' : 'expanded'"
+    >
+      <button v-if="expandingRow" class="bx--table-expand__button" @click="toggleExpand">
+        <ChevronRight16 class="bx--table-expand__svg" />
+      </button>
+    </td>
+    <td v-if="hasBatchActions" class="bx--table-column-checkbox">
+      <cv-checkbox :form-item="false" :value="value" v-model="dataChecked" @change="onChange" ref="rowChecked" />
+    </td>
+    <slot />
+    <td v-if="hasOverflowMenu" class="bx--table-column-menu">
+      <cv-overflow-menu flip-menu>
+        <cv-overflow-menu-item
+          v-for="(item, index) in overflowMenu"
+          :key="`${index}`"
+          @click="
+            onMenuItemClick({
+              rowValue: value,
+              menuIndex: index,
+              menuLabel: item,
+            })
+          "
+          >{{ item }}</cv-overflow-menu-item
+        >
+      </cv-overflow-menu>
+    </td>
+  </tr>
+</template>
+
+<script>
+import CvCheckbox from '../cv-checkbox/cv-checkbox';
+import CvOverflowMenu from '../cv-overflow-menu/cv-overflow-menu';
+import CvOverflowMenuItem from '../cv-overflow-menu/cv-overflow-menu-item';
+import uidMixin from '../../mixins/uid-mixin';
+import ChevronRight16 from '@rocketsoftware/icons-vue/es/chevron--right/16';
+
+export default {
+  name: 'CvDataTableRowInner',
+  components: { CvCheckbox, CvOverflowMenu, CvOverflowMenuItem, ChevronRight16 },
+  mixins: [uidMixin],
+  props: {
+    checked: Boolean,
+    expanded: Boolean,
+    expandingRow: Boolean,
+    overflowMenu: Array,
+    someExpandingRows: Boolean,
+    value: { type: String, requried: true },
+  },
+  model: {
+    event: 'change',
+    prop: 'checked',
+  },
+  data() {
+    return {
+      dataChecked: this.checked,
+      dataExpanded: this.expanded,
+      dataSomeExpandingRows: this.someExpandingRows,
+    };
+  },
+  watch: {
+    checked() {
+      this.dataChecked = this.checked;
+    },
+    expanded() {
+      this.dataExpanded = this.expanded;
+    },
+    someExpandingRows() {
+      this.dataSomeExpandingRows = this.someExpandingRows;
+    },
+  },
+  mounted() {
+    this.$parent.$emit('cv:mounted', this);
+  },
+  beforeDestroy() {
+    this.$parent.$emit('cv:beforeDestroy', this);
+  },
+  computed: {
+    isCvDataTableRow() {
+      return true;
+    },
+    hasOverflowMenu() {
+      return (this.overflowMenu && this.overflowMenu.length) || this.$slots['overflow-menu'];
+    },
+    hasBatchActions() {
+      return this.$parent.$parent.hasBatchActions;
+    },
+    isChecked() {
+      return this.dataChecked;
+    },
+  },
+  methods: {
+    onChange() {
+      this.$parent.$parent.onRowCheckChange(this.value, this.dataChecked);
+    },
+    onMenuItemClick(val) {
+      this.$parent.$parent.onMenuItemClick(val);
+    },
+    toggleExpand() {
+      this.dataExpanded = !this.dataExpanded;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.cv-data-table-row-inner .cv-checkbox.bx--checkbox-wrapper {
+  margin: 0;
+}
+</style>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table-action.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table-action.vue
@@ -1,0 +1,15 @@
+<template>
+  <button class="bx--overflow-menu bx--toolbar-action" v-on="$listeners">
+    <slot></slot>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'cv-data-table-action',
+  mounted() {
+    // ensure SVG has
+    this.$el.children[0].classList.add('class="bx--toolbar-action__icon');
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table-cell.vue
@@ -13,11 +13,18 @@
 </template>
 
 <script>
+import CvTag from "../cv-tag/cv-tag";
 export default {
   name: 'CvDataTableCell',
-  data() {return {filts: ["passed", "xpassed", "failed", "xfailed", "error", "skipped"]}},
   props: {
-    cellStyle: {}
+    cellStyle: {},
+    filts: {
+      type: [String, String, String, String, String, String],
+      default: ["passed", "xpassed", "failed", "xfailed", "error", "skipped"]
+    }
   },
+  components: {
+    CvTag
+  }
 };
 </script>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table-cell.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table-cell.vue
@@ -1,0 +1,23 @@
+<template>
+  <td :style="cellStyle">
+    <cv-tag
+      v-if="filts.includes(this.$slots.default[0].text)"
+      :id="this.$slots.default[0].text + '-active'"
+      kind="cool-gray"
+      :value="this.$slots.default[0].text"
+      :label="this.$slots.default[0].text"
+    ></cv-tag>
+    <slot v-else/>
+
+  </td>
+</template>
+
+<script>
+export default {
+  name: 'CvDataTableCell',
+  data() {return {filts: ["passed", "xpassed", "failed", "xfailed", "error", "skipped"]}},
+  props: {
+    cellStyle: {}
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table-row.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table-row.vue
@@ -1,0 +1,78 @@
+<template>
+  <tbody v-if="someExpandingRows" class="cv-data-table-row cv-data-table-row--expandable">
+    <cv-data-table-row-inner
+      ref="row"
+      v-bind="$attrs"
+      v-on="$listeners"
+      :expanding-row="dataExpandable"
+      some-expanding-rows
+    >
+      <slot />
+    </cv-data-table-row-inner>
+    <tr v-if="dataExpandable" class="bx--expandable-row bx--expandable-row--hidden" data-child-row>
+      <td colspan="9999">
+        <div class="bx--child-row-inner-container">
+          <slot name="expandedContent" />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+  <cv-data-table-row-inner v-else ref="row" v-bind="$attrs" v-on="$listeners" class="cv-data-table-row">
+    <slot />
+  </cv-data-table-row-inner>
+</template>
+
+<script>
+import CvDataTableRowInner from './_cv-data-table-row-inner';
+
+export default {
+  name: 'CvDataTableRow',
+  components: { CvDataTableRowInner },
+  data() {
+    return {
+      dataExpandable: this.$slots.expandedContent !== undefined,
+      dataSomeExpandingRows: false,
+    };
+  },
+  mounted() {
+    this.$parent.$emit('cv:mounted', this);
+  },
+  updated() {
+    this.dataExpandable = this.$slots.expandedContent !== undefined;
+  },
+  beforeDestroy() {
+    this.$parent.$emit('cv:beforeDestroy', this);
+  },
+  computed: {
+    expandable() {
+      return this.dataExpandable;
+    },
+    isCvDataTableRow() {
+      return true;
+    },
+    isChecked: {
+      get() {
+        return this.$refs.row.dataChecked;
+      },
+      set(val) {
+        this.$refs.row.dataChecked = val;
+      },
+    },
+    someExpandingRows: {
+      get() {
+        return this.dataSomeExpandingRows;
+      },
+      set(val) {
+        this.dataSomeExpandingRows = val;
+
+        if (this.$refs.row) {
+          this.$refs.row.dataSomeExpandingRows = val;
+        }
+      },
+    },
+    value() {
+      return this.$refs.row.value;
+    },
+  },
+};
+</script>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table-skeleton.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table-skeleton.vue
@@ -1,0 +1,50 @@
+<template>
+  <cv-data-table skeleton :data="data" :columns="cols" v-on="$listeners" v-bind="$attrs">
+    <template v-if="$slots['helper-text']" slot="helper-text">
+      <slot name="helper-text" />
+    </template>
+
+    <template v-if="$slots['batch-actions']" slot="batch-actions">
+      <slot name="batch-actions" />
+    </template>
+
+    <template v-if="$slots.actions" slot="actions">
+      <slot name="actions" />
+    </template>
+  </cv-data-table>
+</template>
+
+<script>
+import CvDataTable from './cv-data-table';
+
+const DEFAULTS = {
+  COLS: 5,
+  ROWS: 5,
+};
+
+export default {
+  name: 'CvDataTableSkeleton',
+  components: {
+    CvDataTable,
+  },
+  props: {
+    columns: { type: [Array, Number], default: DEFAULTS.COLS },
+    hasExpandables: Boolean,
+    rows: { type: Number, default: DEFAULTS.ROWS },
+  },
+  computed: {
+    data() {
+      return [...Array(Math.max(this.rows, 1))].map(item => Array(this.cols.length).fill(''));
+    },
+    cols() {
+      return typeof this.columns !== 'number' ? this.columns : Array(Math.max(this.columns, 1)).fill('');
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+// .cv-data-table .bx--table-column-checkbox .bx--checkbox-wrapper {
+//   margin: 0;
+// }
+</style>

--- a/packages/core/src/components/rsquad-exec-table/cv-data-table.vue
+++ b/packages/core/src/components/rsquad-exec-table/cv-data-table.vue
@@ -1,0 +1,432 @@
+<template>
+  <div :style="tableStyle" class="cv-data-table">
+    <div class="bx--data-table-container">
+      <div v-if="hasTableHeader" class="bx--data-table-header">
+        <h4 class="bx--data-table-header__title" v-if="title">{{ title }}</h4>
+        <p v-if="isHelper" class="bx--data-table-header__description">
+          <slot name="helper-text">{{ helperText }}</slot>
+        </p>
+      </div>
+
+      <section v-if="hasToolbar" class="bx--table-toolbar">
+        <div v-if="batchActive" :style="{ minHeight: '48px', maxWidth: '0' }" />
+
+        <div
+          v-if="hasBatchActions"
+          class="bx--batch-actions"
+          :class="{ 'bx--batch-actions--active': batchActive }"
+          aria-label="Table Action Bar"
+        >
+          <div class="bx--action-list">
+            <slot name="batch-actions" />
+            <cv-button class="bx--batch-summary__cancel" small @click="deselect">Cancel</cv-button>
+          </div>
+          <div class="bx--batch-summary">
+            <p class="bx--batch-summary__para">
+              <span data-items-selected>
+                <slot name="items-selected" v-bind:scope="{ count: dataRowsSelected.length }"
+                  >{{ dataRowsSelected.length }} items selected</slot
+                >
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div v-if="($slots.actions || $listeners.search) && !batchActive" class="bx--toolbar-content">
+          <div
+            v-if="$listeners.search"
+            :class="{
+              'bx--toolbar-search-container-active': searchActive,
+              'bx--toolbar-search-container-persistent': !expandingSearch,
+              'bx--toolbar-search-container-expandable': expandingSearch,
+            }"
+            ref="searchContainer"
+          >
+            <div data-search class="bx--search bx--search--sm" role="search">
+              <div
+                class="bx--search-magnifier"
+                tabindex="0"
+                @click="checkSearchExpand(true)"
+                @keydown.enter.prevent="checkSearchExpand(true)"
+                @keydown.space.prevent
+                @keyup.space.prevent="checkSearchExpand(true)"
+                @blur="checkSearchFocus"
+                ref="magnifier"
+              >
+                <Search16 class="bx--toolbar-action__icon" />
+              </div>
+              <label :for="uid" class="bx--label">Search</label>
+              <input
+                class="bx--search-input"
+                type="text"
+                :id="uid"
+                role="search"
+                placeholder="Search"
+                :aria-labelledby="uid"
+                ref="search"
+                v-model="searchValue"
+                @input="onSearch"
+                @blur="checkSearchFocus"
+                @keydown.esc.prevent="checkSearchExpand(false)"
+              />
+              <button
+                class="bx--search-close"
+                :class="{ 'bx--search-close--hidden': !clearSearchVisible }"
+                title="Clear search input"
+                aria-label="Clear search input"
+                @click="onClearClick"
+              >
+                <Close16 />
+              </button>
+            </div>
+          </div>
+          <slot name="actions" />
+        </div>
+      </section>
+
+      <table class="bx--data-table" :class="modifierClasses">
+        <thead>
+          <tr>
+            <th v-if="hasExpandables" class="bx--table-expand" />
+            <th v-if="hasBatchActions" class="bx--table-column-checkbox">
+              <cv-checkbox
+                :form-item="false"
+                value="headingCheck"
+                v-model="headingChecked"
+                @change="onHeadingCheckChange"
+              />
+            </th>
+            <cv-data-table-heading
+              v-for="(column, index) in dataColumns"
+              :key="`${index}:${column}`"
+              :heading="column.label ? column.label : column"
+              :sortable="sortable"
+              :order="column.order"
+              @sort="val => onSort(index, val)"
+              :style="headingStyle(index)"
+              :skeleton="skeleton"
+              :filtered="filtered"
+            />
+            <th v-if="hasOverflowMenu"></th>
+          </tr>
+        </thead>
+
+        <cv-wrapper :tag-type="hasExpandables ? '' : 'tbody'">
+          <slot name="data">
+            <cv-data-table-row
+              v-for="(row, rowIndex) in data"
+              :key="`row:${rowIndex}`"
+              :value="`${rowIndex}`"
+              ref="dataRows"
+              :overflow-menu="overflowMenu"
+            >
+              <cv-data-table-cell
+                v-for="(cell, colIndex) in row"
+                :key="`cell:${colIndex}:${rowIndex}`"
+                :style="dataStyle(colIndex)"
+              >
+                <cv-wrapper :tag-type="skeleton && rowIndex < 1 ? 'span' : ''">{{ cell }}</cv-wrapper>
+              </cv-data-table-cell>
+            </cv-data-table-row>
+          </slot>
+        </cv-wrapper>
+      </table>
+    </div>
+
+    <cv-pagination
+      v-if="pagination"
+      v-bind="pagination"
+      :number-of-items="internalNumberOfItems"
+      @change="$emit('pagination', $event)"
+    >
+      <template v-slot:range-text="{ scope }">
+        <slot name="range-text" v-bind:scope="scope" v-if="$scopedSlots['range-text']" />
+      </template>
+
+      <template v-slot:of-n-pages="{ scope }">
+        <slot name="of-n-pages" v-bind:scope="scope" v-if="$scopedSlots['of-n-pages']"></slot>
+      </template>
+    </cv-pagination>
+  </div>
+</template>
+
+<script>
+import CvDataTableHeading from './_cv-data-table-heading';
+import CvDataTableRow from './cv-data-table-row';
+import CvDataTableCell from './cv-data-table-cell';
+import CvButton from '../cv-button/cv-button';
+import CvCheckbox from '../cv-checkbox/cv-checkbox';
+import CvPagination from '../cv-pagination/cv-pagination';
+import CvWrapper from '../cv-wrapper/_cv-wrapper';
+import uidMixin from '../../mixins/uid-mixin';
+import Search16 from '@rocketsoftware/icons-vue/es/search/16';
+import Close16 from '@rocketsoftware/icons-vue/es/close/16';
+
+const rows = children => children.filter(child => child.isCvDataTableRow);
+
+export default {
+  name: 'RsquadExecTable',
+  components: {
+    CvButton,
+    CvDataTableHeading,
+    CvDataTableRow,
+    CvDataTableCell,
+    CvCheckbox,
+    CvPagination,
+    CvWrapper,
+    Search16,
+    Close16,
+  },
+  mixins: [uidMixin],
+  props: {
+    filtered: Boolean,
+    autoWidth: Boolean,
+    borderless: Boolean,
+    overflowMenu: { type: [Boolean, Array], default: () => [] },
+    pagination: {
+      type: [Boolean, Object],
+      default: false,
+    },
+    rowSize: {
+      type: String,
+      default: 'standard',
+      validator: val => ['compact', 'short', 'standard', 'tall', ''].includes(val),
+    },
+    searchPlaceholder: { type: String, default: 'filter' },
+    sortable: Boolean,
+    title: String,
+    columns: { type: Array, required: true },
+    data: { type: Array, requried: true },
+    zebra: Boolean,
+    rowsSelected: { type: Array, default: () => [] },
+    helperText: { type: String, default: null },
+    expandingSearch: { type: Boolean, default: true },
+    skeleton: Boolean,
+  },
+  model: {
+    prop: 'rows-selected',
+    event: 'row-select-changes',
+  },
+  data() {
+    return {
+      dataColumns: this.sortable
+        ? this.columns.map(item => ({
+            label: item.label ? item.label : item,
+            order: 'none',
+          }))
+        : this.columns,
+      batchActive: false,
+      headingChecked: false,
+      dataRowsSelected: this.rowsSelected,
+      searchValue: '',
+      clearSearchVisible: false,
+      searchActive: false,
+      registeredRows: [],
+    };
+  },
+  watch: {
+    sortable() {
+      this.watchColumns();
+    },
+    columns() {
+      this.watchColumns();
+    },
+    rowsSelected() {
+      this.updateRowsSelected();
+    },
+  },
+  created() {
+    // add these on created otherwise cv:mounted is too late.
+    this.$on('cv:mounted', srcComponent => this.onCvMount(srcComponent));
+    this.$on('cv:beforeDestroy', srcComponent => this.onCvBeforeDestroy(srcComponent));
+  },
+  mounted() {
+    this.updateRowsSelected();
+  },
+  computed: {
+    hasBatchActions() {
+      return this.$slots['batch-actions'];
+    },
+    hasTableHeader() {
+      return this.title || this.isHelper;
+    },
+    hasToolbar() {
+      return this.$slots.actions || this.$listeners.search || this.$slots['batch-actions'];
+    },
+    hasExpandables() {
+      return this.registeredRows.some(item => item.expandable);
+    },
+    hasOverflowMenu() {
+      return this.overflowMenu === true || (this.overflowMenu && this.overflowMenu.length > 0);
+    },
+    tableStyle() {
+      return this.autoWidth ? { width: 'initial' } : { width: '100%' };
+    },
+    internalPagination() {
+      if (typeof this.pagination === 'object') {
+        return this.pagination;
+      } else {
+        if (this.pagination === true) {
+          return {};
+        }
+      }
+      return false;
+    },
+    internalNumberOfItems() {
+      if (this.internalPagination.numberOfItems !== undefined) {
+        return this.internalPagination.numberOfItems;
+      } else {
+        return this.registeredRows.length;
+      }
+    },
+    modifierClasses() {
+      const prefix = 'bx--data-table--';
+      const sizeClass = this.rowSize.length === 0 || this.rowSize === 'standard' ? '' : `${prefix}${this.rowSize} `;
+      const zebraClass = this.zebra ? `${prefix}zebra ` : '';
+      const borderlessClass = this.borderless ? `${prefix}no-border ` : '';
+      const skeletonClass = this.skeleton ? `bx--skeleton` : '';
+      return `${sizeClass}${zebraClass}${borderlessClass}${skeletonClass}`.trimRight();
+    },
+    headingStyle() {
+      return index => this.dataColumns[index].headingStyle;
+    },
+    dataStyle() {
+      return index => this.dataColumns[index].dataStyle;
+    },
+    selectedRows() {
+      return this.dataRowsSelected;
+    },
+    isHelper() {
+      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
+    },
+  },
+  methods: {
+    onCvMount(row) {
+      this.registeredRows.push(row);
+      this.updateSomeExpandingRows();
+    },
+    onCvBeforeDestroy(row) {
+      const index = this.registeredRows.findIndex(item => row.uid === item.uid);
+      this.registeredRows.slice(index, 1);
+      this.updateSomeExpandingRows();
+    },
+    checkSearchFocus(ev) {
+      if (!this.$refs.searchContainer.contains(ev.relatedTarget)) {
+        this.searchActive = false;
+      }
+    },
+    checkSearchExpand(force) {
+      if (typeof force === 'boolean') {
+        this.searchActive = force;
+      } else {
+        this.searchActive = !this.searchActive;
+      }
+      if (this.searchActive) {
+        this.$nextTick(() => {
+          this.$refs.search.focus();
+        });
+      } else {
+        this.$nextTick(() => {
+          this.$refs.magnifier.focus();
+        });
+      }
+    },
+    updateRowsSelected() {
+      this.dataRowsSelected = [];
+      for (const i in this.$children) {
+        let child = this.$children[i];
+        if (child.isCvDataTableRow) {
+          child.isChecked = this.rowsSelected.includes(child.value);
+
+          if (child.isChecked) {
+            this.dataRowsSelected.push(child.value);
+          }
+        }
+      }
+      this.headingChecked =
+        this.dataRowsSelected.length === this.$children.filter(item => item.isCvDataTableRow).length;
+      this.batchActive = this.dataRowsSelected.length > 0;
+    },
+    onClearClick() {
+      this.searchValue = '';
+      this.clearSearchVisible = false;
+      this.$emit('search', this.searchValue);
+      this.$nextTick(() => {
+        this.$refs.search.focus();
+      });
+    },
+    onHeadingCheckChange() {
+      // check /uncheck all children
+      this.batchActive = this.headingChecked;
+      this.dataRowsSelected = [];
+      for (const child of rows(this.$children)) {
+        if (this.headingChecked) {
+          this.dataRowsSelected.push(child.value);
+        }
+
+        if (child.isChecked !== this.headingChecked) {
+          child.isChecked = this.headingChecked;
+
+          this.$emit('row-select-change', {
+            value: child.value,
+            selected: child.isChecked,
+          });
+        }
+      }
+      this.$emit('row-select-changes', this.dataRowsSelected);
+    },
+    deselect() {
+      this.headingChecked = false;
+      this.onHeadingCheckChange();
+    },
+    onRowCheckChange(value, checked) {
+      let modelSet = new Set(this.dataRowsSelected);
+
+      if (!checked) {
+        modelSet.delete(value);
+      } else {
+        modelSet.add(value);
+      }
+      this.dataRowsSelected = Array.from(modelSet);
+      this.headingChecked = this.dataRowsSelected.length === rows(this.$children).length;
+      this.batchActive = this.dataRowsSelected.length > 0;
+
+      this.$emit('row-select-change', { value, selected: checked });
+      this.$emit('row-select-changes', this.dataRowsSelected);
+    },
+    onMenuItemClick(val) {
+      this.$emit('overflow-menu-click', val);
+    },
+    watchColumns() {
+      this.dataColumns = this.sortable
+        ? this.columns.map(item => ({
+            label: item.label ? item.label : item,
+            order: 'none',
+          }))
+        : this.columns;
+    },
+    onSearch() {
+      this.clearSearchVisible = this.searchValue.length > 0;
+      this.$emit('search', this.searchValue);
+    },
+    onSort(index, val) {
+      for (let column of this.dataColumns) {
+        column.order = 'none';
+      }
+      this.dataColumns[index].order = val;
+      this.$emit('sort', { index, order: val });
+    },
+    updateSomeExpandingRows() {
+      for (const child of rows(this.$children)) {
+        child.someExpandingRows = this.hasExpandables;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+// .cv-data-table .bx--table-column-checkbox .bx--checkbox-wrapper {
+//   margin: 0;
+// }
+</style>

--- a/packages/core/src/components/rsquad-exec-table/index.js
+++ b/packages/core/src/components/rsquad-exec-table/index.js
@@ -1,0 +1,7 @@
+import CvDataTableAction from './cv-data-table-action';
+import CvDataTableCell from './cv-data-table-cell';
+import CvDataTableRow from './cv-data-table-row';
+import RsquadExecTable from './cv-data-table';
+import CvDataTableSkeleton from './cv-data-table-skeleton';
+
+export { RsquadExecTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableSkeleton };


### PR DESCRIPTION
Added a new vue component, rsquad-cycle-table,  to be used in RSQUAD. The table is an edited copy of <cv-data-table> and includes svg's and links depending on the status and executions of the cycle that was passed into it. requires @carbon/icons-vue for svg's

**New**

- <rsquad-cycle-table> requires parameters for columns, data, productID, releaseID, and the current cycle to render svgs, links, and data for the table.

**Removed**

- removed the empty "carbon-vue-example" folder due to errors caused by the folder's presence

![image](https://user-images.githubusercontent.com/53449340/62724156-54523f80-b9e0-11e9-9941-cb0efd903d3a.png)
